### PR TITLE
Change aws-at-wantedly target to wantedly/infrastructure

### DIFF
--- a/infrastructure.md
+++ b/infrastructure.md
@@ -7,7 +7,7 @@ Wantedlyのインフラは、Dockerを使って動作しています。Dockerコ
 
 社員・長期インターンとしてWeb開発を行っていく人に、最低限知ってほしい情報
 
-- [AWS at Wantedly](https://gist.github.com/dtan4/d8cc932f64299f6ed73652eddb6ab9ff)
+- [AWS at Wantedly](https://github.com/wantedly/infrastructure/blob/master/guides/aws/aws-at-wantedly.md)
 - [Docker を Production で使い続ける理由](https://www.wantedly.com/companies/wantedly/post_articles/27548)
 - [Dockerを使ってみよう](https://github.com/wantedly/paus/blob/master/doc/tutorial-docker.md)
 - [Kubernetes 速習会](http://qiita.com/koudaiii/items/d0b3b0b78dc44d97232a)


### PR DESCRIPTION
## WHY

AWS のドキュメントの置き場が @dtan4 の Gist (https://gist.github.com/dtan4/d8cc932f64299f6ed73652eddb6ab9ff) になっていたけど、これを wantedly/infrastructure 以下へ移動した。https://github.com/wantedly/infrastructure/pull/2337

## WHAT

"AWS at Wantedly" リンクの向き先を wantedly/infrastructure に変更する。